### PR TITLE
Add Either and Unit

### DIFF
--- a/source/Octopus.CoreUtilities.Tests/Fixtures/EitherFixture.cs
+++ b/source/Octopus.CoreUtilities.Tests/Fixtures/EitherFixture.cs
@@ -1,0 +1,136 @@
+using System;
+using NUnit.Framework;
+using Octopus.CoreUtilities.Extensions;
+
+namespace Octopus.CoreUtilities.Tests.Fixtures
+{
+    using static EitherExtensions;
+    using Unit = ValueTuple;
+    
+    [TestFixture]
+    public class EitherFixture
+    {
+        [Test]
+        public void ThrowsErrorWhenAccessingLeftWhenInRightState()
+        {
+            Either<string, double> result = 10;
+            Assert.Throws<InvalidOperationException>(() => Assert.IsEmpty(result.Left));
+        }
+        
+        [Test]
+        public void ThrowsErrorWhenAccessingRightWhenInLeftState()
+        {
+            Either<string, double> result = "Go left, kind sir.";
+            Assert.Throws<InvalidOperationException>(() => Assert.GreaterOrEqual(result.Right, 0.00));
+        }
+
+        [Test]
+        public void CanAccessRightValueWhenInCorrectState()
+        {
+            var expected = 10.0;
+            Either<string, double> result = expected;
+            Assert.AreEqual(expected, result.Right);
+        }
+
+        [Test]
+        public void CanAccessLeftValueWhenInCorrectState()
+        {
+            const string expected = "Go left, kind sir.";
+            Either<string, double> result = "Go left, kind sir.";
+            Assert.AreEqual(expected, result.Left);
+        }
+
+        [Test]
+        public void MapInLeftStateDoesNotThrow()
+        {
+            const string expected = "Go left, kind sir.";
+            Either<string, double> result = expected;
+            result.Map(x => x * 5).Map(x => x + 5);
+            Assert.AreEqual(result.Left, expected);
+        }
+
+        [Test]
+        public void CanMapWhenInRightState()
+        {
+            double Calculate(double x) => x * 10 + 1;
+            const double initial = 10d;
+            var expected = Calculate(initial);
+            var result = initial.AsRight<string, double>().Map(Calculate);
+            Assert.AreEqual(expected, result.Right);
+        }
+        
+        [Test]
+        public void SelectInLeftStateDoesNotThrow()
+        {
+            const string expected = "Go left, kind sir.";
+            Either<string, double> result = expected;
+            result.Select(x => x * 5).Select(x => x + 5);
+            Assert.AreEqual(result.Left, expected);
+        }
+
+        [Test]
+        public void SelectWhenInRightState()
+        {
+            double Calculate(double x) => x * 10 + 1;
+            const double initial = 10d;
+            var expected = Calculate(initial);
+            var result = initial.AsRight<string, double>().Select(Calculate);
+            Assert.AreEqual(expected, result.Right);
+        }
+        
+
+        [Test]
+        public void MatchUsesLeftWhenInLeftState()
+        {
+            const string expected = "Left, left!";
+            void AssertLeft(string value) => Assert.AreEqual(expected, value);
+            void ThrowRight(double value) => throw new InvalidOperationException("Should not access right!");
+            var result = "Left, left!".AsLeft<string, double>();
+            Assert.DoesNotThrow(() => result.Match(AssertLeft, ThrowRight));
+        }
+
+        [Test]
+        public void MatchUsersRightWhenInRightState()
+        {
+            const double expected = 10d;
+            void ThrowLeft(string value) => throw new InvalidOperationException("Should not access left!");
+            void AssertRight(double value) => Assert.AreEqual(expected, value);
+            var result = expected.AsRight<string, double>();
+            Assert.DoesNotThrow(() => result.Match(ThrowLeft, AssertRight));
+        }
+
+        [Test]
+        public void BindToRight()
+        {
+            Either<string, double> first = 10d;
+            Either<string, double> second = 20d;
+
+            var result = first.Bind(x => second.Map(y => y + x));
+            Assert.AreEqual(30d, result.Right);
+        }
+
+        [Test]
+        public void BindToLeft()
+        {
+            const string expected = "I Failed";
+            
+            Either<string, double> first = 10d;
+            var second = expected.AsLeft<string, double>();
+
+            var result = first.Bind(x => second.Map(y => y + x));
+            Assert.DoesNotThrow(() =>
+            {
+                Assert.AreEqual(expected, result.Left);
+            });
+        }
+
+        [Test]
+        public void CanPerformActionUsingRightValue()
+        {
+            var value = 0d;
+            const double expected = 10d;
+            expected.AsRight<Unit, double>().Tee(e => e.ForEach(x => value = x)).Map(x => x + 5);
+            Assert.AreEqual(expected, value);
+        }
+    }
+}

--- a/source/Octopus.CoreUtilities.Tests/Octopus.CoreUtilities.Tests.csproj
+++ b/source/Octopus.CoreUtilities.Tests/Octopus.CoreUtilities.Tests.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Octopus.CoreUtilities\Octopus.CoreUtilities.csproj" />
+  </ItemGroup>
+</Project>

--- a/source/Octopus.CoreUtilities.sln
+++ b/source/Octopus.CoreUtilities.sln
@@ -2,6 +2,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Octopus.CoreUtilities", "Octopus.CoreUtilities\Octopus.CoreUtilities.csproj", "{44150B31-0723-4608-A62C-C0A5F9882E28}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Octopus.CoreUtilities.Tests", "Octopus.CoreUtilities.Tests\Octopus.CoreUtilities.Tests.csproj", "{DD7810A5-2D9A-4326-B3D3-99F0146B3B6C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,5 +14,9 @@ Global
 		{44150B31-0723-4608-A62C-C0A5F9882E28}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44150B31-0723-4608-A62C-C0A5F9882E28}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44150B31-0723-4608-A62C-C0A5F9882E28}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD7810A5-2D9A-4326-B3D3-99F0146B3B6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD7810A5-2D9A-4326-B3D3-99F0146B3B6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD7810A5-2D9A-4326-B3D3-99F0146B3B6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD7810A5-2D9A-4326-B3D3-99F0146B3B6C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/source/Octopus.CoreUtilities/Either.cs
+++ b/source/Octopus.CoreUtilities/Either.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using Octopus.CoreUtilities.Extensions;
+
+namespace Octopus.CoreUtilities
+{
+    using static EitherExtensions;
+    using static Prelude;
+    using Unit = ValueTuple;
+
+    public struct Either<L, R>
+    {
+        private L _left;
+
+        public L Left
+        {
+            get
+            {
+                if (IsRight)
+                    throw new InvalidOperationException("Can't access Left when Either is in Right state");
+                return _left;
+            }
+            private set => _left = value;
+        }
+
+        private R _right;
+        public R Right
+        {
+            get
+            {
+                if (IsLeft)
+                    throw new InvalidOperationException("Can't access Right when Either is in Left state");
+
+                return _right;
+            }
+            private set => _right = value;
+        }
+
+        public bool IsRight { get; }
+        public bool IsLeft => !IsRight;
+
+        internal Either(L left)
+        {
+            IsRight = false;
+            _left = left;
+            _right = default(R);
+        }
+
+        internal Either(R right)
+        {
+            IsRight = true;
+            _right = right;
+            _left = default(L);
+        }
+
+        public static implicit operator Either<L, R>(L left) => new Either<L, R>(left);
+        public static implicit operator Either<L, R>(R right) => new Either<L, R>(right);
+
+        public static implicit operator Either<L, R>(Either.Left<L> left) => new Either<L, R>(left.Value);
+        public static implicit operator Either<L, R>(Either.Right<R> right) => new Either<L, R>(right.Value);
+
+        /// <summary>
+        /// Catamorphism for Either, i.e. use left when in left and use right when in right.
+        /// </summary>
+        /// <typeparam name="TR"></typeparam>
+        /// <param name="Left">Function to invoke when in left state</param>
+        /// <param name="Right">Function to invoke when in right state</param>
+        /// <returns></returns>
+        public TR Match<TR>(Func<L, TR> Left, Func<R, TR> Right)
+           => IsLeft ? Left(this.Left) : Right(this.Right);
+
+        /// <summary>
+        /// Catamorphism for Either, i.e. use left when in left and use right when in right.
+        /// </summary>
+        /// <typeparam name="R"></typeparam>
+        /// <param name="Left">Function to invoke when in left state</param>
+        /// <param name="Right">Function to invoke when in right state</param>
+        /// <returns></returns>
+        public Unit Match(Action<L> Left, Action<R> Right)
+           => Match(Left.ToFunc(), Right.ToFunc());
+
+        public IEnumerator<R> AsEnumerable()
+        {
+            if (IsRight) yield return Right;
+        }
+
+        public override string ToString() => Match(l => $"Left({l})", r => $"Right({r})");
+    }
+
+    public static class Either
+    {
+        public struct Left<TL>
+        {
+            internal TL Value { get; }
+            internal Left(TL value) { Value = value; }
+
+            public override string ToString() => $"Left({Value})";
+        }
+
+        public struct Right<TR>
+        {
+            internal TR Value { get; }
+            internal Right(TR value) { Value = value; }
+
+            public override string ToString() => $"Right({Value})";
+        }
+    }
+
+    public static class EitherExtensions
+    {
+        public static Either.Left<TL> Left<TL>(TL l) => new Either.Left<TL>(l);
+        public static Either.Right<TR> Right<TR>(TR r) => new Either.Right<TR>(r);
+        
+        public static Either<TL, TRr> Map<TL, TR, TRr>
+           (this Either<TL, TR> @this, Func<TR, TRr> f)
+           => @this.Match<Either<TL, TRr>>(
+              l => Left(l),
+              r => Right(f(r)));
+
+        public static Either<TLNew, TRNew> Map<TL, TLNew, TR, TRNew>
+           (this Either<TL, TR> @this, Func<TL, TLNew> left, Func<TR, TRNew> right)
+           => @this.Match<Either<TLNew, TRNew>>(
+              l => Left(left(l)),
+              r => Right(right(r)));
+
+        public static Either<TL, Unit> ForEach<TL, TR>
+           (this Either<TL, TR> @this, Action<TR> act)
+           => Map(@this, act.ToFunc());
+
+        public static Either<TL, TRNew> Bind<TL, TR, TRNew>
+           (this Either<TL, TR> @this, Func<TR, Either<TL, TRNew>> f)
+           => @this.Match(
+              l => Left(l),
+              r => f(r));
+
+        public static Either<TL, TRNew> Select<TL, TR, TRNew>(this Either<TL, TR> @this
+           , Func<TR, TRNew> map) => @this.Map(map);
+
+        
+        public static Either<TL, TR> AsLeft<TL, TR>(this TL @source)
+        {
+            return @source;
+        }
+
+        public static Either<TL, TR> AsRight<TL, TR>(this TR @source)
+        {
+            return @source;
+        }
+    }
+}

--- a/source/Octopus.CoreUtilities/Extensions/FunctionalExtensions.cs
+++ b/source/Octopus.CoreUtilities/Extensions/FunctionalExtensions.cs
@@ -3,6 +3,9 @@ using System.Diagnostics;
 
 namespace Octopus.CoreUtilities.Extensions
 {
+    using Unit = ValueTuple;
+    using static Prelude;
+    
     /// <summary>
     /// https://davefancher.com/2015/06/14/functional-c-fluent-interfaces-and-functional-method-chaining/
     /// https://app.pluralsight.com/library/courses/functional-programming-csharp/table-of-contents
@@ -37,5 +40,14 @@ namespace Octopus.CoreUtilities.Extensions
         {
             return fn(@this);
         }
+        
+        public static Func<Unit> ToFunc(this Action action)
+            => () => { action(); return Unit(); };
+
+        public static Func<T, Unit> ToFunc<T>(this Action<T> action)
+            => t => { action(t); return Unit(); };
+
+        public static Func<T1, T2, Unit> ToFunc<T1, T2>(this Action<T1, T2> action)
+            => (T1 t1, T2 t2) => { action(t1, t2); return Unit(); };
     }
 }

--- a/source/Octopus.CoreUtilities/Octopus.CoreUtilities.csproj
+++ b/source/Octopus.CoreUtilities/Octopus.CoreUtilities.csproj
@@ -12,4 +12,7 @@
     <Copyright>Copyright © Octopus Deploy 2017</Copyright>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
 </Project>

--- a/source/Octopus.CoreUtilities/Unit.cs
+++ b/source/Octopus.CoreUtilities/Unit.cs
@@ -1,0 +1,9 @@
+﻿namespace Octopus.CoreUtilities
+{
+    using Unit = System.ValueTuple;
+    
+    public static partial class Prelude
+    {
+        public static Unit Unit() => default(Unit);
+    }
+}


### PR DESCRIPTION
Maybe is a bit limited in its use so this PR adds a suggested implementation for Either so that we can deal with cases where we would return two mutually exclusive return types that would have to be checked each time. This would remove the need to return a tuple or create a new class or use out parameters in a lot of cases as well as enforces the check for left/right case.

Please note that Either isn't supposed to replace Exceptions but can be used to deal with error cases in a safe way. We can always look at introducing Exceptional/Try if we want to deal with exceptions in a more functional way.