### PR TITLE
Added better Any() method and moved some extensions from Shared

### DIFF
--- a/source/Octopus.CoreUtilities/Extensions/ListExtensions.cs
+++ b/source/Octopus.CoreUtilities/Extensions/ListExtensions.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Octopus.CoreUtilities.Extensions
+{
+    public static class ListExtensions
+    {
+        public static int RemoveWhere<TElement>(this IList<TElement>? source, Func<TElement, bool> remove)
+        {
+            if (source == null)
+                return 0;
+
+            var removedCount = 0;
+
+            for (var i = 0; i < source.Count; i++)
+            {
+                var item = source[i];
+                if (!remove(item))
+                    continue;
+
+                source.RemoveAt(i);
+                i--;
+                removedCount++;
+            }
+
+            return removedCount;
+        }
+
+        public static void AddRange<TElement>(this ICollection<TElement>? source, IEnumerable<TElement>? itemsToAdd)
+        {
+            if (itemsToAdd == null || source == null)
+                return;
+
+            foreach (var item in itemsToAdd)
+                source.Add(item);
+        }
+
+        public static void AddRangeUnique<TElement>(this ICollection<TElement>? source, IEnumerable<TElement>? itemsToAdd)
+        {
+            if (itemsToAdd == null || source == null)
+                return;
+
+            foreach (var item in itemsToAdd.Where(item => !source.Contains(item)))
+                source.Add(item);
+        }
+
+        public static void ReplaceAll<TElement>(this ICollection<TElement> source, IEnumerable<TElement> itemsToAdd)
+        {
+            source.Clear();
+            source.AddRange(itemsToAdd);
+        }
+    }
+}

--- a/source/Octopus.CoreUtilities/Octopus.CoreUtilities.csproj
+++ b/source/Octopus.CoreUtilities/Octopus.CoreUtilities.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net40;net452;net5.0</TargetFrameworks>
     <AssemblyName>Octopus.CoreUtilities</AssemblyName>
     <PackageId>Octopus.CoreUtilities</PackageId>
     <PackageIcon>icon.png</PackageIcon>
@@ -18,6 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="\"/>
+    <None Include="icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Welcome to the left hand side of Yak 1. 

This PR adds some new `Any()` methods that are more specific that the `System.Linq.Enumerable.Any` method and therefore will get picked up instead. This solves the [enumerator creation problem](https://github.com/OctopusDeploy/RoslynAnalyzers/pull/1). The `Any` methods are not included in .NET 5 build (and later) because [they fixed it](https://github.com/dotnet/corefx/pull/40377).

I have to pull some more methods from `Octopus.Shared` as there were duplicate extension methods and I couldn't reference both extensions collections in the same file in Server. I also pulled along a few generically useful methods while I was at it (and `Octopus.Core` as well).

`ToHashSet` now exists in `netcoreapp3.1` so again I got a conflict when trying to reference these new extension methods. I've removed those extension methods from this library for the appropriate frameworks.

There were two methods that did the same thing `NotNull()` and `WhereNotNull()` within Shared and Server. I went with the latter.

Lastly I had to cherry pick from other commits to fix up the builds. There are breaking changes on `master` that the authors have not rolled out, so I'm doing a patch off here, which is the last version to be releases.