### PR TITLE
Added type specific None overloads

### DIFF
--- a/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
+++ b/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Octopus.CoreUtilities.Extensions
 {
@@ -46,6 +47,29 @@ namespace Octopus.CoreUtilities.Extensions
 
         public static bool Any<T>(this HashSet<T> list)
             => list.Count > 0;
+
+        public static bool None<T>(this ICollection<T> collection)
+            => collection.Count == 0;
+
+        public static bool None<T>(this List<T> list)
+            => list.Count == 0;
+
+        public static bool None<T>(this T[] array)
+            => array.Length > 0;
+
+        public static bool None<TKey, TValue>(this IDictionary<TKey, TValue> list)
+            where TKey : notnull
+            => list.Count == 0;
+
+        public static bool None<TKey, TValue>(this ILookup<TKey, TValue> list)
+            => list.Count == 0;
+
+        public static bool None<TKey, TValue>(this Dictionary<TKey, TValue> list)
+            where TKey : notnull
+            => list.Count == 0;
+
+        public static bool None<T>(this HashSet<T> list)
+            => list.Count == 0;
 #endif
 
 #if NET452 || NETSTANDARD2_0 || NETCOREAPP3_1
@@ -54,31 +78,16 @@ namespace Octopus.CoreUtilities.Extensions
 
         public static bool Any<T>(this IReadOnlyCollection<T> list)
             => list.Count > 0;
+
+        public static bool None<T>(this IReadOnlyList<T> list)
+            => list.Count == 0;
+
+        public static bool None<T>(this IReadOnlyCollection<T> list)
+            => list.Count == 0;
 #endif
 
         public static bool None<T>(this IEnumerable<T> items)
-        {
-            if (items == null)
-                throw new ArgumentNullException(nameof(items));
-
-            switch (items)
-            {
-                case ICollection coll:
-                    return coll.Count == 0;
-#if !NET40
-                case IReadOnlyList<T> list:
-                    return list.Count == 0;
-                case IReadOnlyCollection<T> collection:
-                    return collection.Count == 0;
-#endif
-                case IList<T> list:
-                    return list.Count == 0;
-                case ICollection<T> collection:
-                    return collection.Count == 0;
-                default:
-                    return !items.Any();
-            }
-        }
+            => !items.Any();
 
         public static bool None<T>(this IEnumerable<T> items, Func<T, bool> predicate)
             => !items.Any(predicate);

--- a/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
+++ b/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
@@ -22,7 +22,6 @@ namespace Octopus.CoreUtilities.Extensions
         }
 #endif
 
-#if NET40 || NET452 || NETSTANDARD2_0 || NETCOREAPP3_1
         // In .NET 5.0 Enumerable.Any() calls Count/Length so these are no longer needed
         // https://github.com/dotnet/corefx/pull/40377
         public static bool Any<T>(this ICollection<T> collection)
@@ -48,6 +47,14 @@ namespace Octopus.CoreUtilities.Extensions
         public static bool Any<T>(this HashSet<T> list)
             => list.Count > 0;
 
+#if !NET40
+        public static bool Any<T>(this IReadOnlyList<T> list)
+            => list.Count > 0;
+
+        public static bool Any<T>(this IReadOnlyCollection<T> list)
+            => list.Count > 0;
+#endif
+
         public static bool None<T>(this ICollection<T> collection)
             => collection.Count == 0;
 
@@ -70,15 +77,8 @@ namespace Octopus.CoreUtilities.Extensions
 
         public static bool None<T>(this HashSet<T> list)
             => list.Count == 0;
-#endif
 
-#if NET452 || NETSTANDARD2_0 || NETCOREAPP3_1
-        public static bool Any<T>(this IReadOnlyList<T> list)
-            => list.Count > 0;
-
-        public static bool Any<T>(this IReadOnlyCollection<T> list)
-            => list.Count > 0;
-
+#if !NET40
         public static bool None<T>(this IReadOnlyList<T> list)
             => list.Count == 0;
 

--- a/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
+++ b/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
@@ -22,9 +22,7 @@ namespace Octopus.CoreUtilities.Extensions
         }
 #endif
 
-        // In .NET 5.0 Enumerable.Any() calls Count/Length so these are no longer needed
-        // https://github.com/dotnet/corefx/pull/40377
-        public static bool Any<T>(this ICollection<T> collection)
+       public static bool Any<T>(this ICollection<T> collection)
             => collection.Count > 0;
 
         public static bool Any<T>(this List<T> list)

--- a/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
+++ b/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
@@ -55,7 +55,7 @@ namespace Octopus.CoreUtilities.Extensions
             => list.Count == 0;
 
         public static bool None<T>(this T[] array)
-            => array.Length > 0;
+            => array.Length == 0;
 
         public static bool None<TKey, TValue>(this IDictionary<TKey, TValue> list)
             where TKey : notnull


### PR DESCRIPTION
After some more testing, the switch statement in the None method is still pretty expensive. Adding the specific overloads however makes improves things markedly. This also means that the .NET 5.0 implementation won't be as good, so we should keep these overloads.