### PR TITLE
let future SDK versions be used

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.104"
+    "version": "5.0.104",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Without this, once the build environment has a future SDK version it may fail to build.