### PR TITLE
.Net 6 upgrade

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.104",
+    "version": "6.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "6.0.300",
     "rollForward": "latestFeature"
   }
 }

--- a/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
+++ b/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
@@ -10,18 +10,6 @@ namespace Octopus.CoreUtilities.Extensions
 {
     public static class EnumerableExtensions
     {
-#if NET40 || NET452 // ToHashSet was added to System.Linq in 4.7.2, NetStandard 2.1
-        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
-        {
-            return new HashSet<T>(source);
-        }
-
-        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer)
-        {
-            return new HashSet<T>(source, comparer);
-        }
-#endif
-
        public static bool Any<T>(this ICollection<T> collection)
             => collection.Count > 0;
 
@@ -45,14 +33,6 @@ namespace Octopus.CoreUtilities.Extensions
         public static bool Any<T>(this HashSet<T> list)
             => list.Count > 0;
 
-#if !NET40
-        public static bool Any<T>(this IReadOnlyList<T> list)
-            => list.Count > 0;
-
-        public static bool Any<T>(this IReadOnlyCollection<T> list)
-            => list.Count > 0;
-#endif
-
         public static bool None<T>(this ICollection<T> collection)
             => collection.Count == 0;
 
@@ -75,14 +55,6 @@ namespace Octopus.CoreUtilities.Extensions
 
         public static bool None<T>(this HashSet<T> list)
             => list.Count == 0;
-
-#if !NET40
-        public static bool None<T>(this IReadOnlyList<T> list)
-            => list.Count == 0;
-
-        public static bool None<T>(this IReadOnlyCollection<T> list)
-            => list.Count == 0;
-#endif
 
         public static bool None<T>(this IEnumerable<T> items)
             => !items.Any();
@@ -117,13 +89,6 @@ namespace Octopus.CoreUtilities.Extensions
         {
             yield return item;
         }
-
-#if !NET40
-        public static IReadOnlyCollection<T> AsReadOnly<T>(this IEnumerable<T> items)
-        {
-            return new ReadOnlyCollection<T>(items.ToList());
-        }
-#endif
 
         public static IDictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> keyValuePairs)
             where TKey : notnull

--- a/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
+++ b/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
@@ -32,6 +32,12 @@ namespace Octopus.CoreUtilities.Extensions
 
         public static bool Any<T>(this HashSet<T> list)
             => list.Count > 0;
+        
+        public static bool Any<T>(this IReadOnlyList<T> list)
+            => list.Count > 0;
+
+        public static bool Any<T>(this IReadOnlyCollection<T> list)
+            => list.Count > 0;
 
         public static bool None<T>(this ICollection<T> collection)
             => collection.Count == 0;
@@ -54,6 +60,12 @@ namespace Octopus.CoreUtilities.Extensions
             => list.Count == 0;
 
         public static bool None<T>(this HashSet<T> list)
+            => list.Count == 0;
+
+        public static bool None<T>(this IReadOnlyList<T> list)
+            => list.Count == 0;
+
+        public static bool None<T>(this IReadOnlyCollection<T> list)
             => list.Count == 0;
 
         public static bool None<T>(this IEnumerable<T> items)
@@ -88,6 +100,11 @@ namespace Octopus.CoreUtilities.Extensions
         public static IEnumerable<TSource> Yield<TSource>(this TSource item)
         {
             yield return item;
+        }
+
+        public static IReadOnlyCollection<T> AsReadOnly<T>(this IEnumerable<T> items)
+        {
+            return new ReadOnlyCollection<T>(items.ToList());
         }
 
         public static IDictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> keyValuePairs)

--- a/source/Octopus.CoreUtilities/Octopus.CoreUtilities.csproj
+++ b/source/Octopus.CoreUtilities/Octopus.CoreUtilities.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net40;net452;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <AssemblyName>Octopus.CoreUtilities</AssemblyName>
     <PackageId>Octopus.CoreUtilities</PackageId>
     <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
Removed targetting of .Net Framework. We now only target .Net Standard 2.0.

Increased .net Core version to 6