### PR TITLE
Add separate .net Standard 2.0 and .net Standard 2.1 builds

### DIFF
--- a/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
+++ b/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
@@ -10,7 +10,18 @@ namespace Octopus.CoreUtilities.Extensions
 {
     public static class EnumerableExtensions
     {
-       public static bool Any<T>(this ICollection<T> collection)
+#if NETSTANDARD2_0 // ToHashSet was added to System.Linq in 4.7.2, NetStandard 2.1
+        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
+        {
+            return new HashSet<T>(source);
+        }
+
+        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer)
+        {
+            return new HashSet<T>(source, comparer);
+        }
+#endif
+        public static bool Any<T>(this ICollection<T> collection)
             => collection.Count > 0;
 
         public static bool Any<T>(this List<T> list)

--- a/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
+++ b/source/Octopus.CoreUtilities/Extensions/EnumerableExtensions.cs
@@ -21,6 +21,7 @@ namespace Octopus.CoreUtilities.Extensions
             return new HashSet<T>(source, comparer);
         }
 #endif
+      
         public static bool Any<T>(this ICollection<T> collection)
             => collection.Count > 0;
 

--- a/source/Octopus.CoreUtilities/Octopus.CoreUtilities.csproj
+++ b/source/Octopus.CoreUtilities/Octopus.CoreUtilities.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>Octopus.CoreUtilities</AssemblyName>
     <PackageId>Octopus.CoreUtilities</PackageId>
     <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
Added separate netstandard2.0 and 2.1 builds so projects that rely on ToHashSet still can