### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
+> **Warning**
+>
+> **Deprecated**
+>
+> This repository has been deprecated and will be archived in the near future.
+# Octopus.CoreUtilities
+
 This repository contains the ShellRunner and other command line invocation things.
 Please see [Contributing](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@
 > This repository has been deprecated and will be archived in the near future.
 # Octopus.CoreUtilities
 
-This repository contains the ShellRunner and other command line invocation things.
+This repository contains the Octopus utilities and extension methods definition.
 Please see [Contributing](CONTRIBUTING.md)


### PR DESCRIPTION
## Background

As part of the Dependency Consolidation project, this library has been absorbed into the Octopus Server solution. It will no longer be maintained as a separate library, and will be archived when current LTS versions of Octopus Server are out of support.

## Results

Add a deprecation warning to the README.